### PR TITLE
Limit the amount of logging files for user/engine logger to 10

### DIFF
--- a/outfacingInterfaces/Helpers/UserLogger.hpp
+++ b/outfacingInterfaces/Helpers/UserLogger.hpp
@@ -61,6 +61,8 @@ private:
     bool shutdown_ = false;
 
     void CreateDirectories(const std::string &dir);
+
+    void CheckAndCleanOldLogs();
 };
 
 #endif // BRACKOCALYPSE_USER_LOGGER_HPP

--- a/src/Helpers/UserLogger.cpp
+++ b/src/Helpers/UserLogger.cpp
@@ -44,6 +44,35 @@ UserLogger::UserLogger() {
 #endif
 }
 
+void UserLogger::CheckAndCleanOldLogs() {
+    const std::string logDir = "logging/game/";
+    const size_t maxLogFiles = 10;
+
+    std::vector<std::filesystem::directory_entry> logFiles;
+
+    // Gather list of log files
+    for (const auto& entry : std::filesystem::directory_iterator(logDir)) {
+        if (entry.is_regular_file()) {
+            logFiles.push_back(entry);
+        }
+    }
+
+    // Sort files by last write time in descending order (newest first)
+    std::sort(logFiles.begin(), logFiles.end(),
+              [](const std::filesystem::directory_entry& a, const std::filesystem::directory_entry& b) {
+                  return std::filesystem::last_write_time(a) > std::filesystem::last_write_time(b);
+              });
+
+    // Delete all files except the newest 10
+    if (logFiles.size() > maxLogFiles) {
+        for (auto it = logFiles.begin() + maxLogFiles; it != logFiles.end(); ++it) {
+            std::cout << "Deleting log file: " << it->path() << std::endl;
+            std::filesystem::remove(it->path());
+        }
+    }
+}
+
+
 void UserLogger::CreateDirectories(const std::string& dir) {
 #if defined(_WIN32)
     std::string command = "mkdir " + dir;
@@ -83,6 +112,7 @@ UserLogger &UserLogger::GetInstance() {
 void UserLogger::OpenLogFile(const std::string &filename) {
     std::lock_guard<std::mutex> lock(fileMutex);
     if (!logFile.is_open()) {
+        CheckAndCleanOldLogs();
         logFile.open(filename, std::ios::out | std::ios::app);
         if (!logFile.is_open()) {
             throw std::runtime_error("Unable to open log file: " + filename);

--- a/src/Logger.cpp
+++ b/src/Logger.cpp
@@ -7,6 +7,7 @@
 #include <sstream>
 #include <chrono>
 #include <sys/stat.h>
+#include <filesystem>
 
 // Current log level
 #ifndef CURRENT_LOG_LEVEL
@@ -40,6 +41,35 @@ Logger::Logger() {
     Initialize();
 #endif
 }
+
+void Logger::CheckAndCleanOldLogs() {
+    const std::string logDir = "logging/engine/";
+    const size_t maxLogFiles = 10;
+
+    std::vector<std::filesystem::directory_entry> logFiles;
+
+    // Gather list of log files
+    for (const auto& entry : std::filesystem::directory_iterator(logDir)) {
+        if (entry.is_regular_file()) {
+            logFiles.push_back(entry);
+        }
+    }
+
+    // Sort files by last write time in descending order (newest first)
+    std::sort(logFiles.begin(), logFiles.end(),
+              [](const std::filesystem::directory_entry& a, const std::filesystem::directory_entry& b) {
+                  return std::filesystem::last_write_time(a) > std::filesystem::last_write_time(b);
+              });
+
+    // Delete all files except the newest 10
+    if (logFiles.size() > maxLogFiles) {
+        for (auto it = logFiles.begin() + maxLogFiles; it != logFiles.end(); ++it) {
+            std::cout << "Deleting log file: " << it->path() << std::endl;
+            std::filesystem::remove(it->path());
+        }
+    }
+}
+
 
 void Logger::CreateDirectories(const std::string& dir) {
 #if defined(_WIN32)
@@ -80,6 +110,9 @@ Logger &Logger::GetInstance() {
 void Logger::OpenLogFile(const std::string &filename) {
     std::lock_guard<std::mutex> lock(fileMutex);
     if (!logFile.is_open()) {
+        // Clean up old logs before opening a new file
+        CheckAndCleanOldLogs();
+
         logFile.open(filename, std::ios::out | std::ios::app);
         if (!logFile.is_open()) {
             throw std::runtime_error("Unable to open log file: " + filename);

--- a/src/Logger.hpp
+++ b/src/Logger.hpp
@@ -31,6 +31,8 @@ public:
     static void Info(const std::string &message);
     static void Debug(const std::string &message);
 
+    void CheckAndCleanOldLogs();
+
     void Initialize();
 
     void Shutdown();


### PR DESCRIPTION
Limit the amount of user/engine logging files to 10.
CheckAndCleanOldLogs() method added to OpenLogFile() method.
Checks if logfiles exceed 10, if true, remove all except the newest 10 logfiles.

close #140 