### PR TITLE
Feature/171 get components in behaviour script

### DIFF
--- a/outfacingInterfaces/Components/AIComponent.hpp
+++ b/outfacingInterfaces/Components/AIComponent.hpp
@@ -15,7 +15,7 @@ struct AIComponent : public IComponent {
 
     ~AIComponent() override = default;
 
-    void Accept(ComponentVisitor &visitor) override {
+    void accept(ComponentVisitor &visitor) override {
         visitor.visit(*this);
     }
 

--- a/outfacingInterfaces/Components/AnimationComponent.hpp
+++ b/outfacingInterfaces/Components/AnimationComponent.hpp
@@ -17,7 +17,7 @@ struct AnimationComponent : public IComponent {
             startPosition = nullptr;
     };
 
-    void Accept(ComponentVisitor &visitor) override {
+    void accept(ComponentVisitor &visitor) override {
         visitor.visit(*this);
     }
 

--- a/outfacingInterfaces/Components/Archetypes/AudioArchetype.hpp
+++ b/outfacingInterfaces/Components/Archetypes/AudioArchetype.hpp
@@ -20,7 +20,7 @@ public:
 
     AudioArchetype(const AudioArchetype &other) : IComponent(other) {}
 
-    void Accept(ComponentVisitor &visitor) override {
+    void accept(ComponentVisitor &visitor) override {
         visitor.visit(*this);
     }
 };

--- a/outfacingInterfaces/Components/Archetypes/RenderArchetype.hpp
+++ b/outfacingInterfaces/Components/Archetypes/RenderArchetype.hpp
@@ -19,7 +19,7 @@ public:
         return std::make_unique<RenderArchetype>(*this);
     }
 
-    void Accept(ComponentVisitor &visitor) override {
+    void accept(ComponentVisitor &visitor) override {
         visitor.visit<RenderArchetype>(*this);
     }
 

--- a/outfacingInterfaces/Components/AudioComponent.hpp
+++ b/outfacingInterfaces/Components/AudioComponent.hpp
@@ -16,7 +16,7 @@ struct AudioComponent : public AudioArchetype {
 
     ~AudioComponent() = default;
 
-    void Accept(ComponentVisitor &visitor) override {
+    void accept(ComponentVisitor &visitor) override {
         visitor.visit(*this);
     }
 

--- a/outfacingInterfaces/Components/BehaviourScript.hpp
+++ b/outfacingInterfaces/Components/BehaviourScript.hpp
@@ -33,7 +33,7 @@ struct BehaviourScript : public IComponent {
     virtual void onUpdate(float deltaTime) {};
 
     template<typename T>
-    typename std::enable_if_t<std::is_base_of<IComponent, T>::value>::type
+    typename std::enable_if<std::is_base_of<IComponent, T>::value, T &>::type
     tryGetComponent() {
         return ComponentStore::GetInstance().tryGetComponent<T>(entityID);
     }

--- a/outfacingInterfaces/Components/BehaviourScript.hpp
+++ b/outfacingInterfaces/Components/BehaviourScript.hpp
@@ -23,11 +23,17 @@ struct BehaviourScript : public IComponent {
         OnStart();
     }
 
-    BehaviourScript(const BehaviourScript& other) : IComponent(other) {}
+    BehaviourScript(const BehaviourScript &other) : IComponent(other) {}
 
     virtual void OnStart() {};
 
     virtual void OnUpdate(float deltaTime) {};
+
+    template<typename T>
+    typename std::enable_if_t<std::is_base_of<IComponent, T>::value>::type
+    tryGetComponent() {
+        return ComponentStore::GetInstance().tryGetComponent<T>(entityID);
+    }
 };
 
 

--- a/outfacingInterfaces/Components/BehaviourScript.hpp
+++ b/outfacingInterfaces/Components/BehaviourScript.hpp
@@ -7,7 +7,10 @@
 
 #include "IComponent.hpp"
 #include "../../src/Components/ComponentVisitor.hpp"
+#include "../../src/GameObjectConverter.hpp"
 #include <functional>
+#include <Objects/GameObject.hpp>
+#include <optional>
 
 struct BehaviourScript : public IComponent {
     explicit BehaviourScript() = default;
@@ -18,21 +21,37 @@ struct BehaviourScript : public IComponent {
         return std::make_unique<BehaviourScript>(*this);
     }
 
-    void Accept(ComponentVisitor &visitor) override {
+    void accept(ComponentVisitor &visitor) override {
         visitor.visit(*this);
-        OnStart();
+        onStart();
     }
 
     BehaviourScript(const BehaviourScript &other) : IComponent(other) {}
 
-    virtual void OnStart() {};
+    virtual void onStart() {};
 
-    virtual void OnUpdate(float deltaTime) {};
+    virtual void onUpdate(float deltaTime) {};
 
     template<typename T>
     typename std::enable_if_t<std::is_base_of<IComponent, T>::value>::type
     tryGetComponent() {
         return ComponentStore::GetInstance().tryGetComponent<T>(entityID);
+    }
+
+    static std::optional<GameObject> getGameObjectByName(const std::string &name) {
+        return GameObjectConverter::getGameObjectByName(name);
+    }
+
+    static std::vector<GameObject> getGameObjectsByName(const std::string &name) {
+        return GameObjectConverter::getGameObjectsByName(name);
+    }
+
+    static std::optional<GameObject> getGameObjectByTag(const std::string &tag) {
+        return GameObjectConverter::getGameObjectByTag(tag);
+    }
+
+    static std::vector<GameObject> getGameObjectsByTag(const std::string &tag) {
+        return GameObjectConverter::getGameObjectsByTag(tag);
     }
 };
 

--- a/outfacingInterfaces/Components/BoxCollisionComponent.hpp
+++ b/outfacingInterfaces/Components/BoxCollisionComponent.hpp
@@ -28,7 +28,7 @@ struct BoxCollisionComponent : public CollisionComponent {
     }
 
 
-    void Accept(ComponentVisitor &visitor) override {
+    void accept(ComponentVisitor &visitor) override {
         visitor.visit(*this);
     }
 

--- a/outfacingInterfaces/Components/CameraComponent.hpp
+++ b/outfacingInterfaces/Components/CameraComponent.hpp
@@ -27,7 +27,7 @@ struct CameraComponent : public IComponent {
         return std::make_unique<CameraComponent>(*this);
     }
 
-    void Accept(ComponentVisitor &visitor) override {
+    void accept(ComponentVisitor &visitor) override {
         visitor.visit(*this);
     }
 

--- a/outfacingInterfaces/Components/ChildComponent.hpp
+++ b/outfacingInterfaces/Components/ChildComponent.hpp
@@ -21,7 +21,7 @@ struct ChildComponent : public IComponent {
     ~ChildComponent() override = default;
 
 
-    void Accept(ComponentVisitor &visitor) override {
+    void accept(ComponentVisitor &visitor) override {
         visitor.visit(*this);
     }
 

--- a/outfacingInterfaces/Components/CircleCollisionComponent.hpp
+++ b/outfacingInterfaces/Components/CircleCollisionComponent.hpp
@@ -30,7 +30,7 @@ struct CircleCollisionComponent : public IComponent {
             radius = std::make_unique<Vector2>(*other.radius);
     }
 
-    void Accept(ComponentVisitor &visitor) override {
+    void accept(ComponentVisitor &visitor) override {
         visitor.visit(*this);
     }
 

--- a/outfacingInterfaces/Components/ClickableComponent.hpp
+++ b/outfacingInterfaces/Components/ClickableComponent.hpp
@@ -25,7 +25,7 @@ struct ClickableComponent : public IComponent {
         OnClick = other.OnClick;
     }
 
-    void Accept(ComponentVisitor &visitor) override {
+    void accept(ComponentVisitor &visitor) override {
         visitor.visit(*this);
     }
 

--- a/outfacingInterfaces/Components/CollisionComponent.hpp
+++ b/outfacingInterfaces/Components/CollisionComponent.hpp
@@ -18,7 +18,7 @@ struct CollisionComponent : public TransformComponent {
 
     virtual ~CollisionComponent() = default;
 
-    void Accept(ComponentVisitor &visitor) override {
+    void accept(ComponentVisitor &visitor) override {
         visitor.visit(*this);
     }
 

--- a/outfacingInterfaces/Components/IComponent.hpp
+++ b/outfacingInterfaces/Components/IComponent.hpp
@@ -22,7 +22,7 @@ struct IComponent {
 
     virtual std::unique_ptr<IComponent> clone() const = 0;
 
-    virtual void Accept(ComponentVisitor &visitor) {};
+    virtual void accept(ComponentVisitor &visitor) {};
 
 
     // Als we nog achter andere overeenkomende dingen komen bij ieder component kunnen we die hier toevoegens

--- a/outfacingInterfaces/Components/InputTag.hpp
+++ b/outfacingInterfaces/Components/InputTag.hpp
@@ -17,7 +17,7 @@ struct InputTag : public IComponent {
         return std::make_unique<InputTag>(*this);
     }
 
-    void Accept(ComponentVisitor &visitor) override {
+    void accept(ComponentVisitor &visitor) override {
         visitor.visit(*this);
     }
 

--- a/outfacingInterfaces/Components/ObjectInfoComponent.hpp
+++ b/outfacingInterfaces/Components/ObjectInfoComponent.hpp
@@ -19,7 +19,7 @@ struct ObjectInfoComponent : public IComponent {
         return std::make_unique<ObjectInfoComponent>(*this);
     }
 
-    void Accept(ComponentVisitor &visitor) override {
+    void accept(ComponentVisitor &visitor) override {
         visitor.visit(*this);
     }
 

--- a/outfacingInterfaces/Components/ObjectInfoComponent.hpp
+++ b/outfacingInterfaces/Components/ObjectInfoComponent.hpp
@@ -21,9 +21,11 @@ struct ObjectInfoComponent : public IComponent {
 
     void accept(ComponentVisitor &visitor) override {
         visitor.visit(*this);
+        EntityManager::getInstance().addEntityWithName(entityID, name);
+        EntityManager::getInstance().addEntityWithTag(entityID, tag);
     }
 
-    ObjectInfoComponent(const ObjectInfoComponent& other) : IComponent(other) {
+    ObjectInfoComponent(const ObjectInfoComponent &other) : IComponent(other) {
         name = other.name;
         tag = other.tag;
         layer = other.layer;

--- a/outfacingInterfaces/Components/ParentComponent.hpp
+++ b/outfacingInterfaces/Components/ParentComponent.hpp
@@ -19,7 +19,7 @@ struct ParentComponent : public IComponent {
         return std::make_unique<ParentComponent>(*this);
     }
 
-    void Accept(ComponentVisitor &visitor) override {
+    void accept(ComponentVisitor &visitor) override {
         visitor.visit(*this);
     }
 

--- a/outfacingInterfaces/Components/ParticleComponent.hpp
+++ b/outfacingInterfaces/Components/ParticleComponent.hpp
@@ -18,7 +18,7 @@ struct ParticleComponent : public IComponent {
         return std::make_unique<ParticleComponent>(*this);
     }
 
-    void Accept(ComponentVisitor &visitor) override {
+    void accept(ComponentVisitor &visitor) override {
         visitor.visit(*this);
     }
 

--- a/outfacingInterfaces/Components/ParticleEmitterComponent.hpp
+++ b/outfacingInterfaces/Components/ParticleEmitterComponent.hpp
@@ -18,7 +18,7 @@ struct ParticleEmitterComponent : public IComponent {
     }
 
 
-    void Accept(ComponentVisitor &visitor) override {
+    void accept(ComponentVisitor &visitor) override {
         visitor.visit(*this);
     }
 

--- a/outfacingInterfaces/Components/PersistenceTag.hpp
+++ b/outfacingInterfaces/Components/PersistenceTag.hpp
@@ -19,7 +19,7 @@ struct PersistenceTag : public IComponent {
 
     PersistenceTag(const PersistenceTag& other) : IComponent(other) {}
 
-    void Accept(ComponentVisitor &visitor) override {
+    void accept(ComponentVisitor &visitor) override {
         visitor.visit(*this);
     }
 };

--- a/outfacingInterfaces/Components/RectangleComponent.hpp
+++ b/outfacingInterfaces/Components/RectangleComponent.hpp
@@ -30,7 +30,7 @@ struct RectangleComponent : public RenderArchetype {
         return std::make_unique<RectangleComponent>(*this);
     }
 
-    void Accept(ComponentVisitor &visitor) override {
+    void accept(ComponentVisitor &visitor) override {
         visitor.visit<RectangleComponent>(*this);
     }
 

--- a/outfacingInterfaces/Components/RigidBodyComponent.hpp
+++ b/outfacingInterfaces/Components/RigidBodyComponent.hpp
@@ -22,7 +22,7 @@ struct RigidBodyComponent : public IComponent {
          gravityScale = other.gravityScale;
      }
 
-    void Accept(ComponentVisitor &visitor) override {
+    void accept(ComponentVisitor &visitor) override {
         visitor.visit(*this);
     }
 

--- a/outfacingInterfaces/Components/SpriteComponent.hpp
+++ b/outfacingInterfaces/Components/SpriteComponent.hpp
@@ -54,7 +54,7 @@ struct SpriteComponent : public RenderArchetype {
         margin = other.margin;
     }
 
-    void Accept(ComponentVisitor &visitor) override {
+    void accept(ComponentVisitor &visitor) override {
         visitor.visit(*this);
     }
 

--- a/outfacingInterfaces/Components/TextComponent.hpp
+++ b/outfacingInterfaces/Components/TextComponent.hpp
@@ -29,7 +29,7 @@ struct TextComponent : public RenderArchetype {
     }
 
 
-    void Accept(ComponentVisitor &visitor) override {
+    void accept(ComponentVisitor &visitor) override {
         visitor.visit(*this);
     }
 

--- a/outfacingInterfaces/Components/TransformComponent.hpp
+++ b/outfacingInterfaces/Components/TransformComponent.hpp
@@ -27,7 +27,7 @@ struct TransformComponent : public IComponent {
         return std::make_unique<TransformComponent>(*this);
     }
 
-    void Accept(ComponentVisitor &visitor) override {
+    void accept(ComponentVisitor &visitor) override {
         visitor.visit(*this);
     }
 

--- a/outfacingInterfaces/Components/UIComponent.hpp
+++ b/outfacingInterfaces/Components/UIComponent.hpp
@@ -23,7 +23,7 @@ struct UIComponent : public IComponent {
         return std::make_unique<UIComponent>(*this);
     }
 
-    void Accept(ComponentVisitor &visitor) override {
+    void accept(ComponentVisitor &visitor) override {
         visitor.visit(*this);
     }
 

--- a/outfacingInterfaces/Components/VelocityComponent.hpp
+++ b/outfacingInterfaces/Components/VelocityComponent.hpp
@@ -20,7 +20,7 @@ struct VelocityComponent : public IComponent {
         velocity = other.velocity;
     }
 
-    void Accept(ComponentVisitor &visitor) override {
+    void accept(ComponentVisitor &visitor) override {
         visitor.visit(*this);
     }
 

--- a/outfacingInterfaces/EngineManagers/SceneManager.hpp
+++ b/outfacingInterfaces/EngineManagers/SceneManager.hpp
@@ -8,12 +8,13 @@
 
 #include <memory>
 #include "../../src/includes/EntityManager.hpp"
+#include "../../src/GameObjectConverter.hpp"
 
 class Scene;
 
 class SceneManager {
 public:
-    static SceneManager &GetInstance();
+    static SceneManager &getInstance();
 
     ~SceneManager() = default;
 
@@ -25,7 +26,15 @@ public:
 
     SceneManager &operator=(SceneManager &&) = delete;
 
-    void SetActiveScene(Scene &scene);
+    void setActiveScene(Scene &scene);
+
+    static std::optional<GameObject> getGameObjectByName(const std::string &name);
+
+    static std::vector<GameObject> getGameObjectsByName(const std::string &name);
+
+    static std::optional<GameObject> getGameObjectByTag(const std::string &tag);
+
+    static std::vector<GameObject> getGameObjectsByTag(const std::string &tag);
 
 private:
     SceneManager() = default;

--- a/outfacingInterfaces/Objects/GameObject.hpp
+++ b/outfacingInterfaces/Objects/GameObject.hpp
@@ -11,6 +11,7 @@
 #include <string>
 #include <typeinfo>
 #include <stdexcept>
+#include "../src/includes/ComponentStore.hpp"
 
 class GameObject {
 public:
@@ -72,12 +73,17 @@ public:
 
     template<typename T>
     typename std::enable_if<std::is_base_of<IComponent, T>::value, T&>::type
-    TryGetComponent() const {
-        for (const auto &comp : components) {
-            if (auto castedComp = dynamic_cast<T*>(comp.get())) {
-                return *castedComp; // dereference the pointer to return a reference
+    tryGetComponent() const {
+        if(entityID == 0){
+            for (const auto &comp : components) {
+                if (auto castedComp = dynamic_cast<T*>(comp.get())) {
+                    return *castedComp; // dereference the pointer to return a reference
+                }
             }
+        }else{
+            return ComponentStore::GetInstance().tryGetComponent<T>(entityID);
         }
+
         throw std::runtime_error("Component not found"); // throw an exception if not found
     }
 

--- a/src/BrackEngine.cpp
+++ b/src/BrackEngine.cpp
@@ -71,6 +71,9 @@ void BrackEngine::CreateFPS() {
     ComponentStore::GetInstance().addComponent<TransformComponent>(entityId);
     ComponentStore::GetInstance().addComponent<ObjectInfoComponent>(objectInfoComponent);
     ComponentStore::GetInstance().addComponent<TextComponent>(textComponent);
+
+    EntityManager::getInstance().addEntityWithName(entityId, objectInfoComponent.name);
+    EntityManager::getInstance().addEntityWithTag(entityId, objectInfoComponent.tag);
 }
 
 void BrackEngine::UpdateFPS() {

--- a/src/BrackEngine.cpp
+++ b/src/BrackEngine.cpp
@@ -35,12 +35,12 @@ void BrackEngine::Run() {
         FPSSingleton::GetInstance().Start();
         SystemManager::GetInstance().UpdateSystems(GetDeltaTime());
         FPSSingleton::GetInstance().End();
-//        Logger::Info("FPS: " + std::to_string(FPSSingleton::GetInstance().GetFPS()));
+//        Logger::Info("FPS: " + std::to_string(FPSSingleton::getInstance().GetFPS()));
         if (ConfigSingleton::GetInstance().ShowFPS())
             UpdateFPS();
     }
 
-    SystemManager::GetInstance().CleanUp(); 
+    SystemManager::GetInstance().CleanUp();
 }
 
 float BrackEngine::GetDeltaTime() {
@@ -55,7 +55,7 @@ float BrackEngine::GetDeltaTime() {
 }
 
 void BrackEngine::CreateFPS() {
-    auto entityId = EntityManager::GetInstance().CreateEntity();
+    auto entityId = EntityManager::getInstance().createEntity();
     auto objectInfoComponent = ObjectInfoComponent();
     auto textComponent = TextComponent();
 

--- a/src/EngineManagers/SceneManager.cpp
+++ b/src/EngineManagers/SceneManager.cpp
@@ -8,7 +8,7 @@
 
 SceneManager SceneManager::instance;
 
-void SceneManager::SetActiveScene(Scene &scene) {
+void SceneManager::setActiveScene(Scene &scene) {
     EntityManager::getInstance().clearAllEntities();
     for (auto camera: scene.GetAllCameras())
         GameObjectConverter::addCamera(camera);
@@ -18,6 +18,22 @@ void SceneManager::SetActiveScene(Scene &scene) {
     }
 }
 
-SceneManager &SceneManager::GetInstance() {
+SceneManager &SceneManager::getInstance() {
     return instance;
+}
+
+std::optional<GameObject> SceneManager::getGameObjectByName(const std::string &name) {
+    return GameObjectConverter::getGameObjectByName(name);
+}
+
+std::vector<GameObject> SceneManager::getGameObjectsByName(const std::string &name) {
+    return GameObjectConverter::getGameObjectsByName(name);
+}
+
+std::optional<GameObject> SceneManager::getGameObjectByTag(const std::string &tag) {
+    return GameObjectConverter::getGameObjectByTag(tag);
+}
+
+std::vector<GameObject> SceneManager::getGameObjectsByTag(const std::string &tag) {
+    return GameObjectConverter::getGameObjectsByTag(tag);
 }

--- a/src/EngineManagers/SceneManager.cpp
+++ b/src/EngineManagers/SceneManager.cpp
@@ -9,12 +9,12 @@
 SceneManager SceneManager::instance;
 
 void SceneManager::SetActiveScene(Scene &scene) {
-    EntityManager::GetInstance().ClearAllEntities();
+    EntityManager::getInstance().clearAllEntities();
     for (auto camera: scene.GetAllCameras())
-        GameObjectConverter::AddCamera(camera);
+        GameObjectConverter::addCamera(camera);
 
     for (auto gameObject: scene.GetAllGameObjects()) {
-        GameObjectConverter::AddGameObject(gameObject);
+        GameObjectConverter::addGameObject(gameObject);
     }
 }
 

--- a/src/GameObjectConverter.cpp
+++ b/src/GameObjectConverter.cpp
@@ -6,32 +6,74 @@
 #include "includes/EntityManager.hpp"
 #include "Components/ComponentVisitor.hpp"
 
-Camera GameObjectConverter::GetMainCamera(uint32_t entityID) {
+Camera GameObjectConverter::getMainCamera(uint32_t entityID) {
     return {};
 }
 
-GameObject GameObjectConverter::GetGameObject(uint32_t entityID) {
+GameObject GameObjectConverter::getGameObject(uint32_t entityID) {
     return {};
 }
 
-void GameObjectConverter::AddGameObject(GameObject *gameObject) {
+void GameObjectConverter::addGameObject(GameObject *gameObject) {
     ComponentVisitor componentVisitor;
     auto &components = gameObject->GetAllComponents();
     if (gameObject->GetEntityID() == 0)
-        gameObject->SetEntityID(EntityManager::GetInstance().CreateEntity());
+        gameObject->SetEntityID(EntityManager::getInstance().createEntity());
     for (auto &component: components) {
         component->entityID = gameObject->GetEntityID();
-        component->Accept(componentVisitor);
+        component->accept(componentVisitor);
     }
 }
 
 
-void GameObjectConverter::AddCamera(Camera *camera) {
+void GameObjectConverter::addCamera(Camera *camera) {
     ComponentVisitor componentVisitor;
     if (camera->GetEntityID() == 0)
-        camera->SetEntityID(EntityManager::GetInstance().CreateEntity());
+        camera->SetEntityID(EntityManager::getInstance().createEntity());
     for (auto &component: camera->GetAllComponents()) {
         component->entityID = camera->GetEntityID();
-        component->Accept(componentVisitor);
+        component->accept(componentVisitor);
     }
+}
+
+std::optional<GameObject> GameObjectConverter::getGameObjectByName(const std::string &name) {
+    auto entityId = EntityManager::getInstance().getEntityByName(name);
+    if (entityId == 0)
+        return std::nullopt;
+
+    auto gameObject = GameObject();
+    gameObject.SetEntityID(entityId);
+    return gameObject;
+}
+
+std::vector<GameObject> GameObjectConverter::getGameObjectsByName(const std::string &name) {
+    auto gameObjects = std::vector<GameObject>();
+    auto entityIds = EntityManager::getInstance().getEntitiesByName(name);
+    for (auto entityId: entityIds) {
+        auto gameObject = GameObject();
+        gameObject.SetEntityID(entityId);
+        gameObjects.push_back(gameObject);
+    }
+    return gameObjects;
+}
+
+std::optional<GameObject> GameObjectConverter::getGameObjectByTag(const std::string &tag) {
+    auto entityId = EntityManager::getInstance().getEntityByTag(tag);
+    if (entityId == 0)
+        return std::nullopt;
+
+    auto gameObject = GameObject();
+    gameObject.SetEntityID(entityId);
+    return gameObject;
+}
+
+std::vector<GameObject> GameObjectConverter::getGameObjectsByTag(const std::string &tag) {
+    auto gameObjects = std::vector<GameObject>();
+    auto entityIds = EntityManager::getInstance().getEntitiesByTag(tag);
+    for (auto entityId: entityIds) {
+        auto gameObject = GameObject();
+        gameObject.SetEntityID(entityId);
+        gameObjects.push_back(gameObject);
+    }
+    return gameObjects;
 }

--- a/src/GameObjectConverter.hpp
+++ b/src/GameObjectConverter.hpp
@@ -19,6 +19,14 @@ public:
 
     static void AddCamera(Camera *camera);
 
+    static GameObject GetGameObjectByName(const std::string &name);
+
+    static std::vector<GameObject> GetGameObjectsByName(const std::string &name);
+
+    static GameObject GetGameObjectByTag(const std::string &tag);
+
+    static std::vector<GameObject> GetGameObjectsByTag(const std::string &tag);
+    
     static void RemoveGameObject(GameObject &gameObject);
 };
 

--- a/src/GameObjectConverter.hpp
+++ b/src/GameObjectConverter.hpp
@@ -7,27 +7,28 @@
 
 
 #include <cstdint>
+#include <optional>
 #include "Objects/Camera.hpp"
 
 class GameObjectConverter {
 public:
-    static Camera GetMainCamera(uint32_t entityID);
+    static Camera getMainCamera(uint32_t entityID);
 
-    static GameObject GetGameObject(uint32_t entityID);
+    static GameObject getGameObject(uint32_t entityID);
 
-    static void AddGameObject(GameObject *gameObject);
+    static void addGameObject(GameObject *gameObject);
 
-    static void AddCamera(Camera *camera);
+    static void addCamera(Camera *camera);
 
-    static GameObject GetGameObjectByName(const std::string &name);
+    static std::optional<GameObject> getGameObjectByName(const std::string &name);
 
-    static std::vector<GameObject> GetGameObjectsByName(const std::string &name);
+    static std::vector<GameObject> getGameObjectsByName(const std::string &name);
 
-    static GameObject GetGameObjectByTag(const std::string &tag);
+    static std::optional<GameObject> getGameObjectByTag(const std::string &tag);
 
-    static std::vector<GameObject> GetGameObjectsByTag(const std::string &tag);
-    
-    static void RemoveGameObject(GameObject &gameObject);
+    static std::vector<GameObject> getGameObjectsByTag(const std::string &tag);
+
+    static void removeGameObject(GameObject &gameObject);
 };
 
 

--- a/src/Managers/Entities/EntityManager.cpp
+++ b/src/Managers/Entities/EntityManager.cpp
@@ -2,29 +2,69 @@
 // Created by Stef van Stipdonk on 29/10/2023.
 //
 
+#include <string>
+#include <algorithm>
 #include "../../includes/EntityManager.hpp"
 
 EntityManager EntityManager::instance;
 
-uint32_t EntityManager::CreateEntity() {
+uint32_t EntityManager::createEntity() {
     uint32_t id = nextID++;
     entities.insert(id);
     return id;
 }
 
-void EntityManager::DestroyEntity(uint32_t entity) {
+void EntityManager::destroyEntity(uint32_t entity) {
     entities.erase(entity);
 }
 
-const std::unordered_set<uint32_t> &EntityManager::GetAllEntities() const {
+const std::unordered_set<uint32_t> &EntityManager::getAllEntities() const {
     return entities;
 }
 
-void EntityManager::ClearAllEntities() {
+void EntityManager::clearAllEntities() {
     entities.clear();
 }
 
 
-EntityManager &EntityManager::GetInstance() {
+EntityManager &EntityManager::getInstance() {
     return instance;
+}
+
+void EntityManager::addEntityWithName(uint32_t entity, const std::string &name) {
+    if (entitiesByName.find(name) == entitiesByName.end())
+        entitiesByName[name] = {entity};
+    else if (std::find(entitiesByName[name].begin(), entitiesByName[name].end(), entity) == entitiesByName[name].end())
+        entitiesByName[name].push_back(entity);
+}
+
+void EntityManager::addEntityWithTag(uint32_t entity, const std::string &tag) {
+    if (entitiesByTag.find(tag) == entitiesByTag.end())
+        entitiesByTag[tag] = {entity};
+    else if (std::find(entitiesByTag[tag].begin(), entitiesByTag[tag].end(), entity) == entitiesByTag[tag].end())
+        entitiesByTag[tag].push_back(entity);
+}
+
+std::vector<uint32_t> EntityManager::getEntitiesByName(const std::string &name) const {
+    if (entitiesByName.find(name) != entitiesByName.end())
+        return entitiesByName.at(name);
+    return {};
+}
+
+uint32_t EntityManager::getEntityByName(const std::string &name) const {
+    if (entitiesByName.find(name) != entitiesByName.end())
+        return entitiesByName.at(name)[0];
+    return 0;
+}
+
+std::vector<uint32_t> EntityManager::getEntitiesByTag(const std::string &tag) const {
+    if (entitiesByTag.find(tag) != entitiesByTag.end())
+        return entitiesByTag.at(tag);
+    return {};
+}
+
+uint32_t EntityManager::getEntityByTag(const std::string &tag) const {
+    if (entitiesByTag.find(tag) != entitiesByTag.end())
+        return entitiesByTag.at(tag)[0];
+    return 0;
 }

--- a/src/Managers/Entities/EntityManager.cpp
+++ b/src/Managers/Entities/EntityManager.cpp
@@ -32,6 +32,8 @@ EntityManager &EntityManager::getInstance() {
 }
 
 void EntityManager::addEntityWithName(uint32_t entity, const std::string &name) {
+    if (name.empty())
+        return;
     if (entitiesByName.find(name) == entitiesByName.end())
         entitiesByName[name] = {entity};
     else if (std::find(entitiesByName[name].begin(), entitiesByName[name].end(), entity) == entitiesByName[name].end())
@@ -39,6 +41,8 @@ void EntityManager::addEntityWithName(uint32_t entity, const std::string &name) 
 }
 
 void EntityManager::addEntityWithTag(uint32_t entity, const std::string &tag) {
+    if (tag.empty())
+        return;
     if (entitiesByTag.find(tag) == entitiesByTag.end())
         entitiesByTag[tag] = {entity};
     else if (std::find(entitiesByTag[tag].begin(), entitiesByTag[tag].end(), entity) == entitiesByTag[tag].end())

--- a/src/Objects/Button.cpp
+++ b/src/Objects/Button.cpp
@@ -29,64 +29,64 @@ Button::Button(const Vector2& size, const std::string& text) : UIObject() {
 
 void Button::SetTextColor(const Color& color) {
     if (entityID == 0) {
-        TryGetComponent<TextComponent>().color = std::make_unique<Color>(color);
+        tryGetComponent<TextComponent>().color = std::make_unique<Color>(color);
     } else
         ComponentStore::GetInstance().tryGetComponent<TextComponent>(entityID).color = std::make_unique<Color>(color);
 }
 
 void Button::SetFontPath(const std::string& path) {
     if (entityID == 0) {
-        TryGetComponent<TextComponent>().fontPath = path;
+        tryGetComponent<TextComponent>().fontPath = path;
     } else
         ComponentStore::GetInstance().tryGetComponent<TextComponent>(entityID).fontPath = path;
 }
 
 void Button::SetFontSize(int fontSize) {
     if (entityID == 0) {
-        TryGetComponent<TextComponent>().fontSize = fontSize;
+        tryGetComponent<TextComponent>().fontSize = fontSize;
     } else
         ComponentStore::GetInstance().tryGetComponent<TextComponent>(entityID).fontSize = fontSize;
 }
 
 void Button::SetText(const std::string& string) {
     if (entityID == 0) {
-        TryGetComponent<TextComponent>().text = string;
+        tryGetComponent<TextComponent>().text = string;
     } else
         ComponentStore::GetInstance().tryGetComponent<TextComponent>(entityID).text = string;
 }
 
 void Button::SetFill(const Color& color) {
     if (entityID == 0) {
-        TryGetComponent<RectangleComponent>().fill = std::make_unique<Color>(color);
+        tryGetComponent<RectangleComponent>().fill = std::make_unique<Color>(color);
     } else
         ComponentStore::GetInstance().tryGetComponent<RectangleComponent>(entityID).fill = std::make_unique<Color>(color);
 }
 
 void Button::SetClickEvent(std::function<void()> func) {
-    TryGetComponent<ClickableComponent>().OnClick = std::move(func);
+    tryGetComponent<ClickableComponent>().OnClick = std::move(func);
 }
 
 void Button::SetBorderWidth(int borderWidth) {
     if (entityID == 0) {
-        TryGetComponent<RectangleComponent>().borderWidth = borderWidth;
+        tryGetComponent<RectangleComponent>().borderWidth = borderWidth;
     } else
         ComponentStore::GetInstance().tryGetComponent<RectangleComponent>(entityID).borderWidth = borderWidth;
 }
 
 void Button::SetBorderColor(const Color& color) {
     if (entityID == 0) {
-        TryGetComponent<RectangleComponent>().borderColor = std::make_unique<Color>(color);
+        tryGetComponent<RectangleComponent>().borderColor = std::make_unique<Color>(color);
     } else
         ComponentStore::GetInstance().tryGetComponent<RectangleComponent>(entityID).borderColor = std::make_unique<Color>(color);
 }
 
 bool Button::IsDisabled() const {
-    return TryGetComponent<ClickableComponent>().disabled;
+    return tryGetComponent<ClickableComponent>().disabled;
 }
 
 void Button::SetDisabled(bool disabled) {
     if (entityID == 0) {
-        TryGetComponent<ClickableComponent>().disabled = disabled;
+        tryGetComponent<ClickableComponent>().disabled = disabled;
     } else
         ComponentStore::GetInstance().tryGetComponent<ClickableComponent>(entityID).disabled = disabled;
 }

--- a/src/Objects/Camera.cpp
+++ b/src/Objects/Camera.cpp
@@ -19,7 +19,7 @@ Camera::Camera() : GameObject() {
 
 void Camera::SetBackgroundColor(const Color &color) {
     if (entityID == 0) {
-        TryGetComponent<CameraComponent>().backgroundColor = std::make_unique<Color>(color);
+        tryGetComponent<CameraComponent>().backgroundColor = std::make_unique<Color>(color);
     } else
         ComponentStore::GetInstance().tryGetComponent<CameraComponent>(
                 entityID).backgroundColor = std::make_unique<Color>(color);
@@ -27,14 +27,14 @@ void Camera::SetBackgroundColor(const Color &color) {
 
 void Camera::SetSize(const Vector2 &size) {
     if (entityID == 0) {
-        TryGetComponent<CameraComponent>().size = std::make_unique<Vector2>(size);
+        tryGetComponent<CameraComponent>().size = std::make_unique<Vector2>(size);
     } else
         ComponentStore::GetInstance().tryGetComponent<CameraComponent>(entityID).size = std::make_unique<Vector2>(size);
 }
 
 void Camera::SetOnScreenPosition(const Vector2 &position) {
     if (entityID == 0) {
-        TryGetComponent<CameraComponent>().onScreenPosition = std::make_unique<Vector2>(position);
+        tryGetComponent<CameraComponent>().onScreenPosition = std::make_unique<Vector2>(position);
     } else
         ComponentStore::GetInstance().tryGetComponent<CameraComponent>(
                 entityID).onScreenPosition = std::make_unique<Vector2>(position);

--- a/src/Objects/GameObject.cpp
+++ b/src/Objects/GameObject.cpp
@@ -17,7 +17,7 @@ std::vector<GameObject> GameObject::GetChildren() {
 
 std::string GameObject::GetName() const{
     if (entityID == 0) {
-        return TryGetComponent<ObjectInfoComponent>().name;
+        return tryGetComponent<ObjectInfoComponent>().name;
     }
 
     return ComponentStore::GetInstance().tryGetComponent<ObjectInfoComponent>(entityID).name;
@@ -27,7 +27,7 @@ std::string GameObject::GetName() const{
 
 void GameObject::SetName(std::string name) {
     if (entityID == 0) {
-        TryGetComponent<ObjectInfoComponent>().name = name;
+        tryGetComponent<ObjectInfoComponent>().name = name;
     } else {
         ComponentStore::GetInstance().tryGetComponent<ObjectInfoComponent>(entityID).name = name;
     }
@@ -35,14 +35,14 @@ void GameObject::SetName(std::string name) {
 
 std::string GameObject::GetTag() const{
     if (entityID == 0) {
-        return TryGetComponent<ObjectInfoComponent>().tag;
+        return tryGetComponent<ObjectInfoComponent>().tag;
     }
     return ComponentStore::GetInstance().tryGetComponent<ObjectInfoComponent>(entityID).tag;
 }
 
 void GameObject::SetTag(std::string tag) {
     if (entityID == 0) {
-        TryGetComponent<ObjectInfoComponent>().tag = tag;
+        tryGetComponent<ObjectInfoComponent>().tag = tag;
     } else {
         ComponentStore::GetInstance().tryGetComponent<ObjectInfoComponent>(entityID).tag = tag;
     }
@@ -50,14 +50,14 @@ void GameObject::SetTag(std::string tag) {
 
 bool GameObject::IsActive()const {
     if (entityID == 0) {
-        return TryGetComponent<ObjectInfoComponent>().isActive;
+        return tryGetComponent<ObjectInfoComponent>().isActive;
     }
     return ComponentStore::GetInstance().tryGetComponent<ObjectInfoComponent>(entityID).isActive;
 }
 
 void GameObject::SetActive(bool active) {
     if (entityID == 0) {
-        TryGetComponent<ObjectInfoComponent>().isActive = active;
+        tryGetComponent<ObjectInfoComponent>().isActive = active;
     } else {
         ComponentStore::GetInstance().tryGetComponent<ObjectInfoComponent>(entityID).isActive = active;
     }
@@ -65,14 +65,14 @@ void GameObject::SetActive(bool active) {
 
 int GameObject::GetLayer() const{
     if (entityID == 0) {
-        return TryGetComponent<ObjectInfoComponent>().layer;
+        return tryGetComponent<ObjectInfoComponent>().layer;
     }
     return ComponentStore::GetInstance().tryGetComponent<ObjectInfoComponent>(entityID).layer;
 }
 
 void GameObject::SetLayer(int layer) {
     if (entityID == 0) {
-        TryGetComponent<ObjectInfoComponent>().layer = layer;
+        tryGetComponent<ObjectInfoComponent>().layer = layer;
     } else {
         ComponentStore::GetInstance().tryGetComponent<ObjectInfoComponent>(entityID).layer = layer;
     }

--- a/src/Objects/Text.cpp
+++ b/src/Objects/Text.cpp
@@ -16,28 +16,28 @@ Text::Text(const std::string& text) : UIObject() {
 
 void Text::SetFontSize(int fontSize) {
     if (entityID == 0) {
-        TryGetComponent<TextComponent>().fontSize = fontSize;
+        tryGetComponent<TextComponent>().fontSize = fontSize;
     } else
         ComponentStore::GetInstance().tryGetComponent<TextComponent>(entityID).fontSize = fontSize;
 }
 
 void Text::SetColor(const Color &color) {
     if (entityID == 0) {
-        TryGetComponent<TextComponent>().color = std::make_unique<Color>(color);
+        tryGetComponent<TextComponent>().color = std::make_unique<Color>(color);
     } else
         ComponentStore::GetInstance().tryGetComponent<TextComponent>(entityID).color = std::make_unique<Color>(color);
 }
 
 void Text::SetFontPath(const std::string &font) {
     if (entityID == 0) {
-        TryGetComponent<TextComponent>().fontPath = font;
+        tryGetComponent<TextComponent>().fontPath = font;
     } else
         ComponentStore::GetInstance().tryGetComponent<TextComponent>(entityID).fontPath = font;
 }
 
 void Text::SetText(const std::string &text) {
     if (entityID == 0) {
-        TryGetComponent<TextComponent>().text = text;
+        tryGetComponent<TextComponent>().text = text;
     } else
         ComponentStore::GetInstance().tryGetComponent<TextComponent>(entityID).text = text;
 }

--- a/src/Systems/BehaviourScriptSystem.cpp
+++ b/src/Systems/BehaviourScriptSystem.cpp
@@ -17,7 +17,7 @@ BehaviourScriptSystem::~BehaviourScriptSystem() {
 void BehaviourScriptSystem::update(float deltaTime) {
     auto behaviorScripts = ComponentStore::GetInstance().getAllComponentsOfType<BehaviourScript>();
     for (auto script: behaviorScripts) {
-        script->OnUpdate(deltaTime);
+        script->onUpdate(deltaTime);
     }
 }
 

--- a/src/Systems/BehaviourScriptSystem.cpp
+++ b/src/Systems/BehaviourScriptSystem.cpp
@@ -17,7 +17,7 @@ void BehaviourScriptSystem::Update(float deltaTime) {
     auto entities = ComponentStore::GetInstance().getEntitiesWithComponent<BehaviourScript>();
     for (auto entity: entities) {
         auto& behaviourScriptComponent = ComponentStore::GetInstance().tryGetComponent<BehaviourScript>(entity);
-        behaviourScriptComponent.OnUpdate(deltaTime);
+        behaviourScriptComponent.onUpdate(deltaTime);
     }
 }
 

--- a/src/includes/ComponentStore.hpp
+++ b/src/includes/ComponentStore.hpp
@@ -8,6 +8,7 @@
 #include <random>
 #include "Components/IComponent.hpp"
 #include "../Logger.hpp"
+#include "EntityManager.hpp"
 
 class ComponentStore {
 public:

--- a/src/includes/EntityManager.hpp
+++ b/src/includes/EntityManager.hpp
@@ -7,12 +7,14 @@
 
 
 #include <unordered_set>
+#include <map>
+#include <vector>
 #include <cstdint>
 
 class EntityManager {
 
 public:
-    static EntityManager &GetInstance();
+    static EntityManager &getInstance();
 
     ~EntityManager() = default;
 
@@ -24,14 +26,25 @@ public:
 
     EntityManager &operator=(EntityManager &&) = delete;
 
-    uint32_t CreateEntity();
+    uint32_t createEntity();
 
-    void DestroyEntity(uint32_t entity);
+    void destroyEntity(uint32_t entity);
 
-    const std::unordered_set<uint32_t> &GetAllEntities() const;
+    const std::unordered_set<uint32_t> &getAllEntities() const;
 
-    void ClearAllEntities();
+    void clearAllEntities();
 
+    void addEntityWithName(uint32_t entity, const std::string &name);
+
+    void addEntityWithTag(uint32_t entity, const std::string &tag);
+
+    std::vector<uint32_t> getEntitiesByName(const std::string &name) const;
+
+    uint32_t getEntityByName(const std::string &name) const;
+
+    std::vector<uint32_t> getEntitiesByTag(const std::string &tag) const;
+
+    uint32_t getEntityByTag(const std::string &tag) const;
 
 private:
     static EntityManager instance;
@@ -40,6 +53,8 @@ private:
 
     std::unordered_set<uint32_t> entities;
     uint32_t nextID = 1; // Start from 1 for simplicity.
+    std::map<std::string, std::vector<uint32_t>> entitiesByName;
+    std::map<std::string, std::vector<uint32_t>> entitiesByTag;
 };
 
 


### PR DESCRIPTION
# Checklist

## Code kwaliteit
- [x] Functies, variablen en classes gebruiken de juiste casing
- [x] Code is duidelijk en begrijplijk (eventueel comentaar voor meer duidelijkheid)
- [x] Functies zijn compact en doen alleen wat de functie naam impliceert

## Testen
-	[x] De applicatie runned via MinGW
-	[x] De applicatie runned een POSIX-systeem
-	[x] De applicatie geeft geen waarschuwingen
-	[x] De functionaliteit voldoet aan de user story van de klant
-	[x] Er is een good flow getest
-	[x] Er is een bad flow getest

Het is nu mogelijk om vanuit een eigen gedefineerd behaviourScript componenten op te halen van het entiteit waar het Script aan zit. Hier kan de methode tryGetComponent<>() voor gebruikt worden. Ook is het mogelijk om GameObjecten op te halen door middel van de methodes getGameObjectByName en getGameObjectByTag. Dit haalt het eerst gevonden object terug met de naam of tag. Het is ook mogelijk om alle objecten met een name of tag op te halen. Hiervoor zijn de volgende methodes getGameObjectsByName en getGameObjectsByTag. Deze vier methodes zijn ook vanuit de SceneManager singleton aan te roepen zodat het mogelijk is om dit te gebruiken in een OnClick methode van een button.