### PR TITLE
Fix/get world position for objects

### DIFF
--- a/outfacingInterfaces/Components/BehaviourScript.hpp
+++ b/outfacingInterfaces/Components/BehaviourScript.hpp
@@ -59,10 +59,7 @@ struct BehaviourScript : public IComponent {
 
     void setActive(bool active) {
         EntityManager::getInstance().setEntityActive(entityID, active);
-    }
-
-    bool isActive() {
-        return EntityManager::getInstance().isEntityActive(entityID);
+        tryGetComponent<ObjectInfoComponent>().isActive = active;
     }
 };
 

--- a/outfacingInterfaces/EngineManagers/SceneManager.hpp
+++ b/outfacingInterfaces/EngineManagers/SceneManager.hpp
@@ -7,6 +7,7 @@
 
 
 #include <memory>
+#include "../Components/TransformComponent.hpp"
 #include "../../src/includes/EntityManager.hpp"
 #include "../../src/GameObjectConverter.hpp"
 

--- a/outfacingInterfaces/EngineManagers/SceneManager.hpp
+++ b/outfacingInterfaces/EngineManagers/SceneManager.hpp
@@ -36,6 +36,8 @@ public:
 
     static std::vector<GameObject> getGameObjectsByTag(const std::string &tag);
 
+    static Vector2 getWorldPosition(const TransformComponent &transformComponent);
+
 private:
     SceneManager() = default;
 

--- a/outfacingInterfaces/Helpers/Vector2.hpp
+++ b/outfacingInterfaces/Helpers/Vector2.hpp
@@ -47,6 +47,14 @@ public:
 
     Vector2 operator/(const float &other) const;
 
+    void operator+=(const Vector2 &other);
+
+    void operator-=(const Vector2 &other);
+
+    void operator*=(const float &other);
+
+    void operator/=(const float &other);
+
 private:
     float x, y;
 };

--- a/src/EngineManagers/InputManager.cpp
+++ b/src/EngineManagers/InputManager.cpp
@@ -149,7 +149,7 @@ Vector2 InputManager::getWorldMousePosition() const {
             return mouseWorldPosition;
         }
     }
-    return Vector2(0, 0);
+    return {0, 0};
 }
 
 bool InputManager::isPositionInsideSquare(const Vector2 &position, const Vector2 &squarePosition,

--- a/src/EngineManagers/SceneManager.cpp
+++ b/src/EngineManagers/SceneManager.cpp
@@ -4,7 +4,6 @@
 
 #include <Components/ChildComponent.hpp>
 #include <Components/ParentComponent.hpp>
-#include <Components/TransformComponent.hpp>
 #include "EngineManagers/SceneManager.hpp"
 #include "Objects/Scene.hpp"
 #include "../GameObjectConverter.hpp"
@@ -49,6 +48,7 @@ Vector2 SceneManager::getWorldPosition(const TransformComponent &transformCompon
                 transformComponent.entityID).parentId;
         auto &parentTransform = ComponentStore::GetInstance().tryGetComponent<TransformComponent>(parentId);
         position += getWorldPosition(parentTransform);
+        return position;
     }
     catch (std::runtime_error &e) {
         return position;

--- a/src/EngineManagers/SceneManager.cpp
+++ b/src/EngineManagers/SceneManager.cpp
@@ -4,6 +4,7 @@
 
 #include <Components/ChildComponent.hpp>
 #include <Components/ParentComponent.hpp>
+#include <Components/TransformComponent.hpp>
 #include "EngineManagers/SceneManager.hpp"
 #include "Objects/Scene.hpp"
 #include "../GameObjectConverter.hpp"
@@ -39,4 +40,17 @@ std::optional<GameObject> SceneManager::getGameObjectByTag(const std::string &ta
 
 std::vector<GameObject> SceneManager::getGameObjectsByTag(const std::string &tag) {
     return GameObjectConverter::getGameObjectsByTag(tag);
+}
+
+Vector2 SceneManager::getWorldPosition(const TransformComponent &transformComponent) {
+    auto position = *transformComponent.position;
+    try {
+        auto parentId = ComponentStore::GetInstance().tryGetComponent<ParentComponent>(
+                transformComponent.entityID).parentId;
+        auto &parentTransform = ComponentStore::GetInstance().tryGetComponent<TransformComponent>(parentId);
+        position += getWorldPosition(parentTransform);
+    }
+    catch (std::runtime_error &e) {
+        return position;
+    }
 }

--- a/src/Helpers/Vector2.cpp
+++ b/src/Helpers/Vector2.cpp
@@ -72,3 +72,23 @@ bool Vector2::operator==(const Vector2 &other) const {
 bool Vector2::operator!=(const Vector2 &other) const {
     return x != other.x || y != other.y;
 }
+
+void Vector2::operator+=(const Vector2 &other) {
+    x += other.x;
+    y += other.y;
+}
+
+void Vector2::operator-=(const Vector2 &other) {
+    x -= other.x;
+    y -= other.y;
+}
+
+void Vector2::operator*=(const float &other) {
+    x *= other;
+    y *= other;
+}
+
+void Vector2::operator/=(const float &other) {
+    x /= other;
+    y /= other;
+}

--- a/src/Objects/GameObject.cpp
+++ b/src/Objects/GameObject.cpp
@@ -61,7 +61,7 @@ void GameObject::setTag(std::string name) const {
 }
 
 bool GameObject::isActive() const {
-    return tryGetComponent<ObjectInfoComponent>().isActive;
+    return EntityManager::getInstance().isEntityActive(entityID) && tryGetComponent<ObjectInfoComponent>().isActive;
 }
 
 void GameObject::setActive(bool active) const {


### PR DESCRIPTION
# Checklist

## Code kwaliteit
- [x] Functies, variablen en classes gebruiken de juiste casing
- [x] Code is duidelijk en begrijplijk (eventueel comentaar voor meer duidelijkheid)
- [x] Functies zijn compact en doen alleen wat de functie naam impliceert

## Testen
-	[x] De applicatie runned via MinGW
-	[x] De applicatie runned een POSIX-systeem
-	[x] De applicatie geeft geen waarschuwingen
-	[x] De functionaliteit voldoet aan de user story van de klant
-	[x] Er is een good flow getest
-	[x] Er is een bad flow getest

Added a method in the SceneManager to get the worldPosition of any TransformObject