### PR TITLE
Modify everywhere to unique pointers or references to those pointers

### DIFF
--- a/outfacingInterfaces/BrackEngine.hpp
+++ b/outfacingInterfaces/BrackEngine.hpp
@@ -17,7 +17,7 @@
 
 class BrackEngine {
 public:
-    BrackEngine(Config &&config);
+    BrackEngine(std::unique_ptr<Config> config);
 
     ~BrackEngine() = default;
 

--- a/outfacingInterfaces/Components/BehaviourScript.hpp
+++ b/outfacingInterfaces/Components/BehaviourScript.hpp
@@ -33,19 +33,15 @@ struct BehaviourScript : public IComponent {
         return ComponentStore::GetInstance().tryGetComponent<T>(entityID);
     }
 
-    static std::optional<GameObject *> getGameObjectByName(const std::string &name) {
+    static std::optional<GameObject> getGameObjectByName(const std::string &name) {
         return GameObjectConverter::getGameObjectByName(name);
     }
-
-    static std::vector<GameObject> getGameObjectsByName(const std::string &name) {
-        return GameObjectConverter::getGameObjectsByName(name);
-    }
-
+    
     static std::optional<GameObject> getGameObjectByTag(const std::string &tag) {
         return GameObjectConverter::getGameObjectByTag(tag);
     }
 
-    static std::vector<GameObject *> getGameObjectsByTag(const std::string &tag) {
+    static std::vector<GameObject> getGameObjectsByTag(const std::string &tag) {
         return GameObjectConverter::getGameObjectsByTag(tag);
     }
 

--- a/outfacingInterfaces/Components/CircleCollisionComponent.hpp
+++ b/outfacingInterfaces/Components/CircleCollisionComponent.hpp
@@ -15,7 +15,7 @@
 struct CircleCollisionComponent : public IComponent {
 
     explicit CircleCollisionComponent(float xRadius, float yRadius)
-            : IComponent(), radius(new Vector2(xRadius, yRadius)) {}
+            : IComponent(), radius(std::make_unique<Vector2>(xRadius, yRadius)) {}
 
     explicit CircleCollisionComponent(float radius) : CircleCollisionComponent(radius, radius) {}
 

--- a/outfacingInterfaces/Components/ObjectInfoComponent.hpp
+++ b/outfacingInterfaces/Components/ObjectInfoComponent.hpp
@@ -25,7 +25,7 @@ struct ObjectInfoComponent : public IComponent {
         isActive = other.isActive;
     }
 
-    std::string name, tag;
+    std::string name, tag = "";
     int layer;
     bool isActive = true;
 };

--- a/outfacingInterfaces/EngineManagers/SceneManager.hpp
+++ b/outfacingInterfaces/EngineManagers/SceneManager.hpp
@@ -29,17 +29,17 @@ public:
 
     void setActiveScene(Scene &scene);
 
-    static std::optional<GameObject> getGameObjectByName(const std::string &name);
+    std::optional<GameObject> getGameObjectByName(const std::string &name);
 
-    static std::vector<GameObject> getGameObjectsByName(const std::string &name);
+    std::optional<GameObject> getGameObjectByTag(const std::string &tag);
 
-    static std::optional<GameObject> getGameObjectByTag(const std::string &tag);
+    std::vector<GameObject *> getGameObjectsByTag(const std::string &tag);
 
-    static std::vector<GameObject *> getGameObjectsByTag(const std::string &tag);
-
-    static Vector2 getWorldPosition(const TransformComponent &transformComponent);
+    Vector2 getWorldPosition(const TransformComponent &transformComponent);
 
     std::string getActiveSceneSignature();
+
+    Scene &getActiveScene();
 
 private:
     SceneManager() = default;
@@ -47,6 +47,7 @@ private:
     static SceneManager instance;
     bool hasChanged = false;
 
+    std::optional<std::reference_wrapper<Scene>> activeScene;
     std::string activeSceneSignature;
 
 };

--- a/outfacingInterfaces/Objects/GameObject.hpp
+++ b/outfacingInterfaces/Objects/GameObject.hpp
@@ -22,7 +22,8 @@ public:
     GameObject(entity id);
 
     ~GameObject() {
-
+        children.clear();
+        components.clear();
     };
 
     GameObject &operator=(const GameObject &other) {

--- a/outfacingInterfaces/Objects/Scene.hpp
+++ b/outfacingInterfaces/Objects/Scene.hpp
@@ -21,15 +21,15 @@ public:
 
     void addGameObject(std::unique_ptr<GameObject> gameObject);
 
-    GameObject *getGameObjectByName(const std::string name);
+    std::unique_ptr<GameObject> &getGameObjectByName(const std::string name);
 
     std::vector<GameObject *> getGameObjectsByTag(const std::string &tag);
 
-    std::vector<GameObject *> getAllGameObjects();
+    std::vector<std::unique_ptr<GameObject>> &getAllGameObjects();
 
-    std::vector<Camera *> getAllCameras();
+    std::vector<std::unique_ptr<Camera>> &getAllCameras();
 
-    void removeGameObject(GameObject &gameObject);
+    void removeGameObject(std::unique_ptr<GameObject> &gameObject);
 
     void removeGameObjectByName(std::string name);
 
@@ -41,12 +41,13 @@ public:
 
 private:
     std::vector<std::unique_ptr<GameObject>> gameObjects;
+    std::map<std::string, std::reference_wrapper<std::unique_ptr<GameObject>>> nameToGameObject;
+    std::map<std::string, std::vector<std::reference_wrapper<std::unique_ptr<GameObject>>>> tagToGameObject;
     std::vector<std::unique_ptr<Camera>> cameras;
 
     std::string generateSignature();
 
     std::string signature;
-
 };
 
 

--- a/src/BrackEngine.cpp
+++ b/src/BrackEngine.cpp
@@ -23,8 +23,8 @@
 #include "Systems/ParticleSystem.hpp"
 
 
-BrackEngine::BrackEngine(Config &&config) {
-    ConfigSingleton::GetInstance().SetConfig(config);
+BrackEngine::BrackEngine(std::unique_ptr<Config> config) {
+    ConfigSingleton::GetInstance().SetConfig(std::move(config));
     SystemManager::getInstance().AddSystem(std::make_shared<InputSystem>());
     SystemManager::getInstance().AddSystem(std::make_shared<ClickSystem>());
     SystemManager::getInstance().AddSystem(std::make_shared<AudioSystem>());

--- a/src/ConfigSingleton.cpp
+++ b/src/ConfigSingleton.cpp
@@ -46,16 +46,16 @@ int ConfigSingleton::getAmountOfSoundEffectsChannels() const {
     return amountOfSoundEffectsChannels;
 }
 
-void ConfigSingleton::SetConfig(Config config) {
-    isRunning = config.isRunning;
-    windowTitle = config.windowTitle;
-    windowSize = config.windowSize;
-    fullscreen = config.fullscreen;
-    BaseAssetPath = config.BaseAssetPath;
-    showFPS = config.showFPS;
-    amountOfSoundEffectsChannels = config.amountOfSoundEffectsChannels;
-    fpsLimit = config.fpsLimit;
-    particleLimit = config.particleLimit;
+void ConfigSingleton::SetConfig(std::unique_ptr<Config> config) {
+    isRunning = config->isRunning;
+    windowTitle = config->windowTitle;
+    windowSize = config->windowSize;
+    fullscreen = config->fullscreen;
+    BaseAssetPath = config->BaseAssetPath;
+    showFPS = config->showFPS;
+    amountOfSoundEffectsChannels = config->amountOfSoundEffectsChannels;
+    fpsLimit = config->fpsLimit;
+    particleLimit = config->particleLimit;
 }
 
 bool ConfigSingleton::ShowFPS() const {

--- a/src/ConfigSingleton.hpp
+++ b/src/ConfigSingleton.hpp
@@ -22,7 +22,7 @@ public:
 
     void operator=(ConfigSingleton &&) = delete;
 
-    void SetConfig(Config config);
+    void SetConfig(std::unique_ptr<Config> config);
 
     void SetIsRunning(bool isRunning);
 

--- a/src/EngineManagers/SceneManager.cpp
+++ b/src/EngineManagers/SceneManager.cpp
@@ -15,30 +15,30 @@ void SceneManager::setActiveScene(Scene &scene) {
     EntityManager::getInstance().clearAllEntities();
     SystemManager::getInstance().clearSystemsCache();
 
-    for (auto camera: scene.getAllCameras())
-        GameObjectConverter::addGameObject(camera);
+    for (auto &camera: scene.getAllCameras())
+        GameObjectConverter::addGameObject(reinterpret_cast<std::unique_ptr<GameObject> &>(camera));
 
-    for (auto gameObject: scene.getAllGameObjects()) {
+    for (auto &gameObject: scene.getAllGameObjects())
         GameObjectConverter::addGameObject(gameObject);
-    }
 
     activeSceneSignature = scene.getSignature();
+    activeScene = scene;
 }
 
 SceneManager &SceneManager::getInstance() {
     return instance;
 }
 
+Scene &SceneManager::getActiveScene() {
+    return activeScene.value();
+}
+
 std::string SceneManager::getActiveSceneSignature() {
     return activeSceneSignature;
 }
 
-std::vector<GameObject> SceneManager::getGameObjectsByName(const std::string &name) {
-    return GameObjectConverter::getGameObjectsByName(name);
-}
-
 std::vector<GameObject *> SceneManager::getGameObjectsByTag(const std::string &tag) {
-    return GameObjectConverter::getGameObjectsByTag(tag);
+    return activeScene->get().getGameObjectsByTag(tag);
 }
 
 Vector2 SceneManager::getWorldPosition(const TransformComponent &transformComponent) {

--- a/src/GameObjectConverter.hpp
+++ b/src/GameObjectConverter.hpp
@@ -14,25 +14,19 @@
 class GameObjectConverter {
 public:
 
-    static void addGameObject(GameObject *gameObject);
+    static void addGameObject(std::unique_ptr<GameObject> &gameObject);
 
-    static std::optional<GameObject *> getGameObjectByName(const std::string &name);
-
-    static std::vector<GameObject> getGameObjectsByName(const std::string &name);
-
+    static std::optional<GameObject> getGameObjectByName(const std::string &name);
+    
     static std::optional<GameObject> getGameObjectByTag(const std::string &tag);
 
-    static std::vector<GameObject *> getGameObjectsByTag(const std::string &tag);
+    static std::vector<GameObject> getGameObjectsByTag(const std::string &tag);
 
     static std::vector<GameObject> getChildren(entity entityID);
 
     static std::optional<GameObject> getParent(entity entityID);
 
-    static void removeGameObject(GameObject &gameObject);
-
-    static void removeGameObject(GameObject *gameObject);
-
-    static void removeGameObjectImpl(GameObject *gameObject);
+    static void removeGameObject(std::unique_ptr<GameObject> &gameObject);
 };
 
 

--- a/src/Managers/Entities/EntityManager.cpp
+++ b/src/Managers/Entities/EntityManager.cpp
@@ -51,9 +51,9 @@ void EntityManager::clearAllEntities() {
     auto persistanceEntities = ComponentStore::GetInstance().getEntitiesWithComponent<PersistenceTag>();
 
     std::unordered_set<entity> copyEnt(entities);
-    for(auto entity : copyEnt) {
+    for (auto entity: copyEnt) {
         auto found = std::find(persistanceEntities.begin(), persistanceEntities.end(), entity);
-        if(found == persistanceEntities.end()) {
+        if (found == persistanceEntities.end()) {
             ComponentStore::GetInstance().removeAllComponents(entity);
             entities.erase(entity);
         }
@@ -68,11 +68,11 @@ EntityManager &EntityManager::getInstance() {
 void EntityManager::addEntityWithName(entity entityId, const std::string &name) {
     if (name.empty())
         return;
+
     if (nameToEntity.find(name) == nameToEntity.end())
-        nameToEntity[name] = {entityId};
-    else if (std::find(nameToEntity[name].begin(), nameToEntity[name].end(), entityId) ==
-             nameToEntity[name].end())
-        nameToEntity[name].push_back(entityId);
+        Logger::GetInstance().Warning("Entity with name " + name + " already exists, and will be overwritten.");
+
+    nameToEntity[name] = {entityId};
 
     entityToName[entityId] = name;
 }
@@ -92,16 +92,10 @@ void EntityManager::addEntity(entity entity) {
     entities.insert(entity);
 }
 
-
-std::vector<entity> EntityManager::getEntitiesByName(const std::string &name) const {
-    if (nameToEntity.find(name) != nameToEntity.end())
-        return nameToEntity.at(name);
-    return {};
-}
-
 entity EntityManager::getEntityByName(const std::string &name) const {
     if (nameToEntity.find(name) != nameToEntity.end())
-        return nameToEntity.at(name)[0];
+        return nameToEntity.find(name)->second;
+
     return 0;
 }
 
@@ -117,7 +111,7 @@ entity EntityManager::getEntityByTag(const std::string &tag) const {
     return 0;
 }
 
-std::map<std::string, std::vector<entity>> EntityManager::getEntitiesByNameMap() const {
+std::map<std::string, entity> EntityManager::getEntitiesByNameMap() const {
     return nameToEntity;
 }
 
@@ -125,7 +119,7 @@ std::map<std::string, std::vector<entity>> EntityManager::getEntitiesByTagMap() 
     return tagToEntity;
 }
 
-void EntityManager::setEntitiesByNameMap(const std::map<std::string, std::vector<entity>> &entitiesByName) {
+void EntityManager::setEntitiesByNameMap(const std::map<std::string, entity> &entitiesByName) {
     EntityManager::nameToEntity = entitiesByName;
 }
 

--- a/src/Systems/AudioSystem.cpp
+++ b/src/Systems/AudioSystem.cpp
@@ -5,7 +5,7 @@
 #include "AudioSystem.hpp"
 #include "../includes/ComponentStore.hpp"
 
-AudioSystem::AudioSystem() : audioWrapper(new AudioWrapper()) {
+AudioSystem::AudioSystem() : audioWrapper(std::make_unique<AudioWrapper>()) {
 }
 
 AudioSystem::~AudioSystem() {

--- a/src/Systems/RenderingSystem.cpp
+++ b/src/Systems/RenderingSystem.cpp
@@ -7,7 +7,7 @@
 #include "../includes/EntityManager.hpp"
 #include "../includes/ComponentStore.hpp"
 
-RenderingSystem::RenderingSystem() : sdl2Wrapper(new RenderWrapper()) {
+RenderingSystem::RenderingSystem() : sdl2Wrapper(std::make_unique<RenderWrapper>()) {
 }
 
 RenderingSystem::~RenderingSystem() {

--- a/src/Systems/ReplaySystem.hpp
+++ b/src/Systems/ReplaySystem.hpp
@@ -16,7 +16,7 @@ class ReplaySystem : public ISystem {
 public:
     struct ECSSnapshot {
         std::unordered_set<entity> entities;
-        std::map<std::string, std::vector<entity>> entitiesByName;
+        std::map<std::string, entity> entitiesByName;
         std::map<std::string, std::vector<entity>> entitiesByTag;
 
         std::unordered_map<std::type_index, std::unordered_map<entity, std::unique_ptr<IComponent>>> componentStates;
@@ -39,6 +39,7 @@ public:
     const std::string getName() const override;
 
     void cleanUp() override;
+
     void clearCache() override;
 
 private:

--- a/src/includes/EntityManager.hpp
+++ b/src/includes/EntityManager.hpp
@@ -38,9 +38,7 @@ public:
     void addEntityWithName(entity entityId, const std::string &name);
 
     void addEntityWithTag(entity entityId, const std::string &tag);
-
-    std::vector<entity> getEntitiesByName(const std::string &name) const;
-
+    
     void addEntitiesByTags(std::map<std::string, std::vector<entity>> entitiesByTag);
 
     void addEntitiesByName(std::map<std::string, std::vector<entity>> entitiesByName);
@@ -53,11 +51,11 @@ public:
 
     entity getEntityByTag(const std::string &tag) const;
 
-    std::map<std::string, std::vector<entity>> getEntitiesByNameMap() const;
+    std::map<std::string, entity> getEntitiesByNameMap() const;
 
     std::map<std::string, std::vector<entity>> getEntitiesByTagMap() const;
 
-    void setEntitiesByNameMap(const std::map<std::string, std::vector<entity>> &entitiesByName);
+    void setEntitiesByNameMap(const std::map<std::string, entity> &entitiesByName);
 
     void setEntitiesByTagMap(const std::map<std::string, std::vector<entity>> &entitiesByTag);
 
@@ -75,7 +73,7 @@ private:
     std::vector<entity> reserveEntities;
     std::map<entity, std::string> entityToName;
     std::map<entity, std::string> entityToTag;
-    std::map<std::string, std::vector<entity>> nameToEntity;
+    std::map<std::string, entity> nameToEntity;
     std::map<std::string, std::vector<entity>> tagToEntity;
     std::map<entity, bool> activeEntities;
 };


### PR DESCRIPTION
Scene maakt nu alleen gebruik van game objects en houdt hier ook aan vast zolang de scene leeft.
Dit ondersteunt ook dat er unique pointer instances blijven bestaan van de objects die gemodificeert kunnen worden.
In de scenemanager wordt nu ook de huidige active scene onthouden zodat methods die dingen toevoegen aan deze scene worden gecalled op dat object inplaats van dat de manager direct in de ecs called.

# Checklist

## Code kwaliteit
- [x] Functies, variablen en classes gebruiken de juiste casing
- [x] Code is duidelijk en begrijplijk (eventueel comentaar voor meer duidelijkheid)
- [x] Functies zijn compact en doen alleen wat de functie naam impliceert

## Testen
-	[ ] De applicatie runned via MinGW
-	[x] De applicatie runned een POSIX-systeem
-	[x] De applicatie geeft geen waarschuwingen
-	[x] De functionaliteit voldoet aan de user story van de klant
-	[x] Er is een good flow getest
-	[x] Er is een bad flow getest

Pr for game:
refactor/use-unique-ptr-everywhere